### PR TITLE
feat: added a token from trello's oauth to authenticate requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ uploads
 
 # env vars
 .env.sh
+config/local.json

--- a/README.md
+++ b/README.md
@@ -19,8 +19,13 @@ You can also use **environment variables**, following [this mapping file](https:
 ```bash
 # Trello interactions
 export ANG_TRELLO_BOARDID=
-export ANG_TRELLO_KEY=
 export ANG_TRELLO_SECRET=
+# API KEY used to request Trello
+export ANG_TRELLO_KEY=
+# Token used to request Trello, should at least have the scope `read`
+# You can generate a token with the account used to manage ANG_TRELLO_KEY :
+# https://trello.com/1/authorize?expiration=never&scope=read&response_type=token&key=$ANG_TRELLO_KEY
+export ANG_TRELLO_TOKEN=
 
 # Mailing
 export ANG_NOTIFICATIONS_RECEIVERS=

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -12,6 +12,7 @@
   "trello": {
     "key": "ANG_TRELLO_KEY",
     "secret": "ANG_TRELLO_SECRET",
+    "tOKEN": "ANG_TRELLO_TOKEN",
     "boardId": "ANG_TRELLO_BOARDID"
   },
   "smtp": {

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -12,7 +12,7 @@
   "trello": {
     "key": "ANG_TRELLO_KEY",
     "secret": "ANG_TRELLO_SECRET",
-    "tOKEN": "ANG_TRELLO_TOKEN",
+    "token": "ANG_TRELLO_TOKEN",
     "boardId": "ANG_TRELLO_BOARDID"
   },
   "smtp": {

--- a/config/default.json
+++ b/config/default.json
@@ -12,6 +12,7 @@
   "trello": {
     "key": "",
     "secret": "",
+    "token": "",
     "boardId": ""
   },
   "smtp": {

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -11,6 +11,7 @@ services:
     environment:
       - ANG_TRELLO_KEY
       - ANG_TRELLO_SECRET
+      - ANG_TRELLO_TOKEN
       - ANG_TRELLO_BOARDID
       - ANG_MONGO_HOST=db
       - ANG_BADGE_HOST=opbadge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       # exemple le board de prod : https://trello.com/b/wEaLnz8d/ezpaarse-analogist-suivi-des-plateformes
       - ANG_TRELLO_KEY
       - ANG_TRELLO_SECRET
+      - ANG_TRELLO_TOKEN
       - ANG_TRELLO_BOARDID
       - ANG_MONGO_HOST=db
       # les variables d'environnement pour les badges

--- a/lib/trello.js
+++ b/lib/trello.js
@@ -5,6 +5,7 @@ const config = require('config')
 
 const baseUrl = 'https://api.trello.com'
 const apiKey = config.trello.key
+const apiToken = config.trello.token
 const boardID = config.trello.boardId
 
 // FIXME: use Purest?
@@ -132,6 +133,7 @@ const trelloWrapper = {
     options = options || {}
     options.qs = options.qs || {}
     options.qs.key = options.qs.key || apiKey
+    options.qs.token = options.qs.token || apiToken
 
     options.url = `${baseUrl}${path}`
     options.method = method


### PR DESCRIPTION
fix: analyses beign inaccessible following Trello's API changes
